### PR TITLE
fix: copy .hbs templates to dist during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp -r src/generator/typescript/templates dist/generator/typescript/templates",
     "dev": "tsx src/cli/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

Closes #1

- `tsc` only emits `.ts` files — Handlebars `.hbs` templates were not copied to `dist/` during build
- Added `cp -r src/generator/typescript/templates dist/generator/typescript/templates` as a post-tsc step in the build script
- Scaffold now finds templates at runtime and completes successfully

## Test plan

- [ ] `npm run build` — completes without error, templates present in `dist/generator/typescript/templates/`
- [ ] `node dist/cli/index.js` — complete all prompts → server directory generated successfully
- [ ] Generated project has all expected files (`src/`, `tests/`, `.mcp/manifest.json`, `README.md`, etc.)
- [ ] `cd <generated> && npm install && npm run build` — generated server builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)