### PR TITLE
feat: smarter scaffold questions to pre-fill tool logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ MCP lets AI assistants like Claude, Cursor, and others call your tools directly.
 ## What it does
 
 1. **Scaffold** — `npx mcpinnit` generates a complete, working MCP server with tool definitions, Zod schemas, tests, Dockerfile, and README
-2. **Test** — `npx mcpinnit test` lets you test tools locally without opening Claude Desktop
-3. **Connect** — `npx mcpinnit install-claude` writes your Claude Desktop config automatically
+2. **Extend** — `npx mcpinnit add-tool` adds a new tool to an existing server and wires it up automatically
+3. **Test** — `npx mcpinnit test` lets you test tools locally without opening Claude Desktop
+4. **Connect** — `npx mcpinnit install-claude` writes your Claude Desktop config automatically
 
 ## Quick Start
 
@@ -24,14 +25,22 @@ MCP lets AI assistants like Claude, Cursor, and others call your tools directly.
 npx mcpinnit
 ```
 
-Answer 5 questions, get a production-ready MCP server:
+Answer a few questions, get a production-ready MCP server:
 
 ```
 ? What is your server name? › weather-tools
+? Short description? › Fetch weather data for any location
 ? Choose transport layer: › stdio (recommended)
 ? Choose language: › TypeScript
 ? Add authentication? › None
 ? Which tool templates to include? › fetch, search
+
+# If fetch is selected, two follow-up questions appear:
+? API base URL? (optional) › https://api.openweathermap.org
+? Default HTTP method? › GET
+
+# For all servers:
+? Environment variables your server needs? › WEATHER_API_KEY
 ```
 
 Then:

--- a/src/cli/scaffold.ts
+++ b/src/cli/scaffold.ts
@@ -77,6 +77,39 @@ export async function scaffold(): Promise<void> {
     },
   });
 
+  // Contextual follow-up questions based on selected tools
+  let apiBaseUrl: string | undefined;
+  let defaultHttpMethod = 'GET';
+
+  if (selectedTools.includes('fetch')) {
+    const baseUrl = await input({
+      message: 'API base URL? (optional — press Enter to skip)',
+      default: '',
+    });
+    apiBaseUrl = baseUrl.trim() || undefined;
+
+    defaultHttpMethod = await select<string>({
+      message: 'Default HTTP method for fetch tool?',
+      default: 'GET',
+      choices: [
+        { value: 'GET' },
+        { value: 'POST' },
+        { value: 'PUT' },
+        { value: 'PATCH' },
+        { value: 'DELETE' },
+      ],
+    });
+  }
+
+  const envVarsInput = await input({
+    message: 'Environment variables your server needs? (comma-separated, e.g. API_KEY,DB_URL — press Enter to skip)',
+    default: '',
+  });
+  const envVars = envVarsInput
+    .split(',')
+    .map((v) => v.trim().toUpperCase())
+    .filter(Boolean);
+
   const options: ScaffoldOptions = {
     serverName: toKebabCase(serverName),
     serverDescription,
@@ -84,6 +117,9 @@ export async function scaffold(): Promise<void> {
     language,
     auth,
     tools: selectedTools,
+    apiBaseUrl,
+    defaultHttpMethod,
+    envVars,
   };
 
   console.log('');

--- a/src/generator/typescript/index.ts
+++ b/src/generator/typescript/index.ts
@@ -40,6 +40,11 @@ export async function generateTypeScriptProject(opts: ScaffoldOptions): Promise<
       namePascal: toPascalCase(t),
       isLast: false,
     })),
+    apiBaseUrl: opts.apiBaseUrl ?? '',
+    hasApiBaseUrl: !!opts.apiBaseUrl,
+    defaultHttpMethod: opts.defaultHttpMethod ?? 'GET',
+    envVars: (opts.envVars ?? []).map((v) => ({ name: v })),
+    hasEnvVars: (opts.envVars ?? []).length > 0,
     version: '1.0.0',
     year: new Date().getFullYear(),
   };

--- a/src/generator/typescript/templates/env.example.hbs
+++ b/src/generator/typescript/templates/env.example.hbs
@@ -14,3 +14,13 @@ OAUTH_CLIENT_SECRET=
 OAUTH_REDIRECT_URI=http://localhost:3000/callback
 OAUTH_SCOPES=read,write
 {{/if}}
+{{#if hasApiBaseUrl}}
+# API base URL for fetch tool
+API_BASE_URL={{apiBaseUrl}}
+{{/if}}
+{{#if hasEnvVars}}
+# Custom environment variables
+{{#each envVars}}
+{{this.name}}=
+{{/each}}
+{{/if}}

--- a/src/generator/typescript/templates/tools/fetch.ts.hbs
+++ b/src/generator/typescript/templates/tools/fetch.ts.hbs
@@ -1,13 +1,21 @@
 import { z } from 'zod';
 import type { ToolDefinition } from '../types.js';
 import { textResult, errorResult } from '../types.js';
+{{#if hasApiBaseUrl}}
+
+const API_BASE_URL = process.env.API_BASE_URL ?? '{{apiBaseUrl}}';
+{{/if}}
 
 const schema = {
+{{#if hasApiBaseUrl}}
+  url: z.string().describe('Path or full URL (e.g. /users/123)'),
+{{else}}
   url: z.string().url().describe('The URL to fetch'),
+{{/if}}
   method: z
     .enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
     .optional()
-    .default('GET')
+    .default('{{defaultHttpMethod}}')
     .describe('HTTP method to use'),
   headers: z
     .record(z.string())
@@ -18,7 +26,12 @@ const schema = {
 
 async function handler(input: z.infer<z.ZodObject<typeof schema>>) {
   try {
-    const res = await fetch(input.url, {
+{{#if hasApiBaseUrl}}
+    const resolvedUrl = input.url.startsWith('http') ? input.url : `${API_BASE_URL}${input.url}`;
+{{else}}
+    const resolvedUrl = input.url;
+{{/if}}
+    const res = await fetch(resolvedUrl, {
       method: input.method,
       headers: input.headers as Record<string, string> | undefined,
       body: input.body,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@ export interface ScaffoldOptions {
   language: 'typescript' | 'python';
   auth: 'none' | 'api-key' | 'oauth2';
   tools: string[];
+  apiBaseUrl?: string;
+  defaultHttpMethod?: string;
+  envVars?: string[];
 }
 
 export interface MCPManifest {


### PR DESCRIPTION
Closes #10

## Summary
- If `fetch` is selected as a tool template, asks two follow-up questions:
  - **API base URL** (optional) — pre-fills `API_BASE_URL` env var and updates the fetch handler to resolve relative paths against it
  - **Default HTTP method** — pre-selects GET/POST/PUT/PATCH/DELETE in the fetch schema
- Asks all users: **"Environment variables your server needs?"** (comma-separated) — adds them to `.env.example` as named stubs
- All new questions are optional / skippable — existing behaviour unchanged if user presses Enter

## Changes
- `src/types.ts` — added `apiBaseUrl?`, `defaultHttpMethod?`, `envVars?` to `ScaffoldOptions`
- `src/cli/scaffold.ts` — conditional follow-up prompts after tool selection
- `src/generator/typescript/index.ts` — passes new context fields to templates
- `templates/tools/fetch.ts.hbs` — uses `hasApiBaseUrl`/`apiBaseUrl`/`defaultHttpMethod` conditionally
- `templates/env.example.hbs` — appends `API_BASE_URL` and custom env var stubs when provided

## Test plan
- [ ] Scaffold with `fetch` selected → confirm API base URL and method questions appear
- [ ] Provide a base URL → confirm `API_BASE_URL` in `.env.example` and `const API_BASE_URL` in `fetch.ts`
- [ ] Provide env vars `API_KEY,DB_URL` → confirm both appear in `.env.example`
- [ ] Skip all new questions (press Enter) → generated output identical to before
- [ ] `npm run build` in generated project compiles clean